### PR TITLE
[YouTube] Fix upload date extraction for lockupViewModel in channel tabs

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
@@ -418,6 +418,11 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
         if (cachedDateText == null) {
             cachedDateText = metadataPart(1, 1)
                     .map(this::getTextContentFromMetadataPart);
+            // Channel tabs omit the uploader name row, so the date is in row 0, part 1
+            if (cachedDateText.isEmpty()) {
+                cachedDateText = metadataPart(0, 1)
+                        .map(this::getTextContentFromMetadataPart);
+            }
         }
         return cachedDateText;
     }


### PR DESCRIPTION
Channel tabs omit the uploader name row in lockupViewModel metadata, so the date is located at row 0, part 1 instead of row 1, part 1.

Without this fix, all videos extracted from channel tabs have null upload dates and are discarded by NewPipe's feed database manager.

Fixes missing videos in subscription feed when channels use the lockupViewModel format in richItemRenderers.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
