### PR TITLE
[YouTube] Fix date/view extraction properly and add tests for lockupViewModel in channel tabs

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
@@ -23,6 +23,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
@@ -327,8 +328,21 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
             return -1;
         }
 
-        final Optional<String> optTextContent = metadataPart(1, 0)
-            .map(this::getTextContentFromMetadataPart);
+        // Search all metadata parts for text that looks like a view count.
+        // YouTube changed from 2 rows [author][views,date] to 1 row [views,date]
+        // so the views text could be in any part of any row.
+        Optional<String> optTextContent = findMetadataPart(text -> {
+            final String lower = text.toLowerCase();
+            return lower.contains("view") || lower.contains("watching")
+                    || lower.contains("recommended") || lower.contains(NO_VIEWS_LOWERCASE);
+        });
+
+        // Fallback to original position if heuristic didn't match
+        if (optTextContent.isEmpty()) {
+            optTextContent = metadataPart(1, 0)
+                    .map(this::getTextContentFromMetadataPart);
+        }
+
         // We could do this inline if the ParsingException would be a RuntimeException -.-
         if (optTextContent.isPresent()) {
             return getViewCountFromViewCountText(optTextContent.get());
@@ -410,15 +424,44 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
         return metadataPart.getObject("text").getString("content");
     }
 
+    /**
+     * Searches all metadata rows and parts for text matching the given predicate.
+     * This handles variable metadata layouts (1 row vs 2 rows, reversed parts, etc.).
+     */
+    private Optional<String> findMetadataPart(@Nonnull final Predicate<String> predicate)
+            throws ParsingException {
+        if (cachedMetadataRows == null) {
+            cachedMetadataRows = JsonUtils.getArray(lockupViewModel,
+                "metadata.lockupMetadataViewModel.metadata"
+                    + ".contentMetadataViewModel.metadataRows");
+        }
+        return cachedMetadataRows
+            .streamAsJsonObjects()
+            .flatMap(jsonObject -> jsonObject.getArray("metadataParts")
+                .streamAsJsonObjects())
+            .map(this::getTextContentFromMetadataPart)
+            .filter(predicate)
+            .findFirst();
+    }
+
     private boolean isLive() throws ParsingException {
         return getStreamType() != StreamType.VIDEO_STREAM;
     }
 
     private Optional<String> getDateText() throws ParsingException {
         if (cachedDateText == null) {
-            cachedDateText = metadataPart(1, 1)
-                    .map(this::getTextContentFromMetadataPart);
-            // Channel tabs omit the uploader name row, so the date is in row 0, part 1
+            // YouTube changed the metadata row structure. It can now be:
+            // - 2 rows: [author] [views, date]  → date is row 1, part 1
+            // - 1 row:  [views, date]            → date could be part 0 or part 1
+            // Search all metadata parts for text that looks like a date.
+            cachedDateText = findMetadataPart(text ->
+                    text.endsWith("ago") || text.contains(PREMIERES_TEXT));
+
+            // Fallback to original positions if heuristic didn't match
+            if (cachedDateText.isEmpty()) {
+                cachedDateText = metadataPart(1, 1)
+                        .map(this::getTextContentFromMetadataPart);
+            }
             if (cachedDateText.isEmpty()) {
                 cachedDateText = metadataPart(0, 1)
                         .map(this::getTextContentFromMetadataPart);

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamInfoItemTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamInfoItemTest.java
@@ -138,6 +138,69 @@ class YoutubeStreamInfoItemTest {
         );
     }
 
+    /**
+     * Tests that findMetadataPart correctly extracts date and view count
+     * from the 1-row format where parts are in normal order: [views, date]
+     */
+    @Test
+    void lockupViewModelOneRowNormal()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelOneRowNormal") + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser);
+        assertAll(
+        () -> assertEquals(StreamType.VIDEO_STREAM, extractor.getStreamType()),
+        () -> assertEquals("Test Video One Row Normal", extractor.getName()),
+        () -> assertEquals("2 hours ago", extractor.getTextualUploadDate()),
+        () -> assertNotNull(extractor.getUploadDate()),
+        () -> assertEquals(3600000, extractor.getViewCount()), // 3.6m views
+        () -> assertEquals(630, extractor.getDuration()) // 10:30
+        );
+    }
+
+    /**
+     * Tests that findMetadataPart correctly extracts date and view count
+     * from the 1-row format where parts are in reversed order: [date, views]
+     */
+    @Test
+    void lockupViewModelOneRowReversed()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelOneRowReversed") + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser);
+        assertAll(
+        () -> assertEquals(StreamType.VIDEO_STREAM, extractor.getStreamType()),
+        () -> assertEquals("Test Video One Row Reversed", extractor.getName()),
+        () -> assertEquals("1 day ago", extractor.getTextualUploadDate()),
+        () -> assertNotNull(extractor.getUploadDate()),
+        () -> assertEquals(1200, extractor.getViewCount()), // 1.2K views
+        () -> assertEquals(300, extractor.getDuration()) // 5:00
+        );
+    }
+
+    /**
+     * Tests that findMetadataPart handles 1-row format with only view count
+     * (no date text present) - e.g. for livestreams with watching count only.
+     */
+    @Test
+    void lockupViewModelOneRowViewsOnly()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelOneRowViewsOnly") + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser);
+        assertAll(
+        () -> assertEquals(StreamType.LIVE_STREAM, extractor.getStreamType()),
+        () -> assertEquals("Test Video One Row Views Only", extractor.getName()),
+        () -> assertNull(extractor.getTextualUploadDate()),
+        () -> assertNull(extractor.getUploadDate()),
+        () -> assertEquals(500, extractor.getViewCount()), // 500 watching
+        () -> assertEquals(-1, extractor.getDuration())
+        );
+    }
+
     @Test
     void emptyTitle() throws FileNotFoundException, JsonParserException {
         final var json = JsonParser.object().from(new FileInputStream(getMockPath(

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelonerownormal.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelonerownormal.json
@@ -1,0 +1,59 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/TEST123/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          }
+        ]
+      },
+      "overlays": [
+        {
+          "thumbnailBottomOverlayViewModel": {
+            "badges": [
+              {
+                "thumbnailBadgeViewModel": {
+                  "text": "10:30",
+                  "badgeStyle": "THUMBNAIL_OVERLAY_BADGE_STYLE_DEFAULT"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "Test Video One Row Normal"
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "3.6m views"
+                  }
+                },
+                {
+                  "text": {
+                    "content": "2 hours ago"
+                  }
+                }
+              ]
+            }
+          ],
+          "delimiter": " • "
+        }
+      }
+    }
+  },
+  "contentId": "TEST123",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelonerowreversed.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelonerowreversed.json
@@ -1,0 +1,59 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/TEST456/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          }
+        ]
+      },
+      "overlays": [
+        {
+          "thumbnailBottomOverlayViewModel": {
+            "badges": [
+              {
+                "thumbnailBadgeViewModel": {
+                  "text": "5:00",
+                  "badgeStyle": "THUMBNAIL_OVERLAY_BADGE_STYLE_DEFAULT"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "Test Video One Row Reversed"
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "1 day ago"
+                  }
+                },
+                {
+                  "text": {
+                    "content": "1.2K views"
+                  }
+                }
+              ]
+            }
+          ],
+          "delimiter": " • "
+        }
+      }
+    }
+  },
+  "contentId": "TEST456",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelonerowviewsonly.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelonerowviewsonly.json
@@ -1,0 +1,54 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/TEST789/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          }
+        ]
+      },
+      "overlays": [
+        {
+          "thumbnailBottomOverlayViewModel": {
+            "badges": [
+              {
+                "thumbnailBadgeViewModel": {
+                  "text": "LIVE",
+                  "badgeStyle": "THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "Test Video One Row Views Only"
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "500 watching"
+                  }
+                }
+              ]
+            }
+          ],
+          "delimiter": " • "
+        }
+      }
+    }
+  },
+  "contentId": "TEST789",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}


### PR DESCRIPTION
Problem: Videos extracted from yt channel tabs have null upload dates and often incorrect view counts. This happens because YoutubeStreamInfoItemLockupExtractor hardcodes metadata row positions that don't match the 1-row format used in channel tabs
NewPipe's FeedDatabaseManager.upsertAll() silently discards videos with null dates, causing the subscription feed to appear empty even though extration succeeds.

Root Cause
  YouTube's lockupViewModel uses different metadata layouts:
  • Related videos (2 rows): [author] [views, date]
  • Channel tabs (1 row): [views, date] or [date, views] — order is variable
The original code assumed fixed positions:
  • metadataPart(1, 1) for date → fails on 1-row format
  • metadataPart(1, 0) for views → fails on 1-row format
  • metadataPart(0, 1) fallback for date → fails when parts are reversed
Changes
  1. findMetadataPart() helper — searches ALL metadata rows and parts for text matching a predicate, instead of hardcoding indices
  2. getDateText() — finds text ending with "ago" or containing "Premieres " anywhere in metadata
  3. getViewCount() — finds text containing "view", "watching", or "recommended" anywhere in metadata
  4. Unit tests — 3 new tests with mock JSON covering
    • 1-row normal: [views, date]
    • 1-row reversed: [date, views]
    • 1-row views-only (livestreams)


- [ ] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.