### PR TITLE
[YouTube] Handle missing metadataRows in lockup extractor & add ANDROID_VR client as fallback for SABR-only responses

### DIFF
--- a/extractor/build.gradle.kts
+++ b/extractor/build.gradle.kts
@@ -131,7 +131,7 @@ publishing {
 
             licenses {
                 license {
-                    name = "GNU GENERAL PUBLIC LICENSE, Version 3"
+                    name = "GNU General Public License v3.0 or later"
                     url = "https://www.gnu.org/licenses/gpl-3.0.txt"
                 }
             }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/ClientsConstants.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/ClientsConstants.java
@@ -109,4 +109,14 @@ final class ClientsConstants {
      * </p>
      */
     static final String ANDROID_CLIENT_VERSION = "21.03.36";
+
+    // ANDROID_VR (Meta Quest YouTube app) client fields
+
+    static final String ANDROID_VR_CLIENT_ID = "28";
+    static final String ANDROID_VR_CLIENT_NAME = "ANDROID_VR";
+    static final String ANDROID_VR_CLIENT_VERSION = "1.65.10";
+    static final String ANDROID_VR_DEVICE_MAKE = "Oculus";
+    static final String ANDROID_VR_DEVICE_MODEL = "Quest 3";
+    static final String ANDROID_VR_OS_VERSION = "12L";
+    static final int ANDROID_VR_SDK_VERSION = 32;
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/InnertubeClientRequestInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/InnertubeClientRequestInfo.java
@@ -6,6 +6,13 @@ import javax.annotation.Nullable;
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_CLIENT_ID;
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_CLIENT_NAME;
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_CLIENT_VERSION;
+import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_VR_CLIENT_ID;
+import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_VR_CLIENT_NAME;
+import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_VR_CLIENT_VERSION;
+import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_VR_DEVICE_MAKE;
+import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_VR_DEVICE_MODEL;
+import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_VR_OS_VERSION;
+import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.ANDROID_VR_SDK_VERSION;
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.DESKTOP_CLIENT_PLATFORM;
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.EMBED_CLIENT_SCREEN;
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.IOS_CLIENT_ID;
@@ -141,5 +148,16 @@ public final class InnertubeClientRequestInfo {
                         IOS_CLIENT_ID, WATCH_CLIENT_SCREEN, null),
                 new InnertubeClientRequestInfo.DeviceInfo(MOBILE_CLIENT_PLATFORM, "Apple",
                         IOS_DEVICE_MODEL, "iOS", IOS_OS_VERSION, -1));
+    }
+
+    @Nonnull
+    public static InnertubeClientRequestInfo ofAndroidVRClient() {
+        return new InnertubeClientRequestInfo(
+                new InnertubeClientRequestInfo.ClientInfo(ANDROID_VR_CLIENT_NAME,
+                        ANDROID_VR_CLIENT_VERSION, ANDROID_VR_CLIENT_ID,
+                        WATCH_CLIENT_SCREEN, null),
+                new InnertubeClientRequestInfo.DeviceInfo(MOBILE_CLIENT_PLATFORM,
+                        ANDROID_VR_DEVICE_MAKE, ANDROID_VR_DEVICE_MODEL,
+                        "Android", ANDROID_VR_OS_VERSION, ANDROID_VR_SDK_VERSION));
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamHelper.java
@@ -228,6 +228,36 @@ public final class YoutubeStreamHelper {
                 getDownloader().postWithContentTypeJson(url, headers, body, localization)));
     }
 
+    public static JsonObject getAndroidVRPlayerResponse(
+            @Nonnull final ContentCountry contentCountry,
+            @Nonnull final Localization localization,
+            @Nonnull final String videoId,
+            @Nonnull final String cpn) throws IOException, ExtractionException {
+        final InnertubeClientRequestInfo innertubeClientRequestInfo =
+                InnertubeClientRequestInfo.ofAndroidVRClient();
+
+        final Map<String, List<String>> headers =
+                getMobileClientHeaders(getAndroidUserAgent(localization));
+
+        innertubeClientRequestInfo.clientInfo.visitorData =
+                YoutubeParsingHelper.getVisitorDataFromInnertube(innertubeClientRequestInfo,
+                        localization, contentCountry, headers, YOUTUBEI_V1_GAPIS_URL, null, false);
+
+        final JsonBuilder<JsonObject> builder = prepareJsonBuilder(localization, contentCountry,
+                innertubeClientRequestInfo, null);
+
+        addVideoIdCpnAndOkChecks(builder, videoId, cpn);
+
+        final byte[] body = JsonWriter.string(builder.done())
+                .getBytes(StandardCharsets.UTF_8);
+
+        final String url = YOUTUBEI_V1_GAPIS_URL + PLAYER + "?" + DISABLE_PRETTY_PRINT_PARAMETER
+                + "&t=" + generateTParameter() + "&id=" + videoId;
+
+        return JsonUtils.toJsonObject(getValidJsonResponseBody(
+                getDownloader().postWithContentTypeJson(url, headers, body, localization)));
+    }
+
     private static void addVideoIdCpnAndOkChecks(@Nonnull final JsonBuilder<JsonObject> builder,
                                                  @Nonnull final String videoId,
                                                  @Nullable final String cpn) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -131,6 +131,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     private JsonObject iosStreamingData;
     @Nullable
     private JsonObject androidStreamingData;
+    @Nullable
+    private JsonObject androidVRStreamingData;
 
     private JsonObject videoPrimaryInfoRenderer;
     private JsonObject videoSecondaryInfoRenderer;
@@ -146,6 +148,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     // three different strings are used.
     private String iosCpn;
     private String androidCpn;
+    private String androidVRCpn;
 
     @Nullable
     private String androidStreamingUrlsPoToken;
@@ -328,7 +331,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             return Long.parseLong(duration);
         } catch (final Exception e) {
             return getDurationFromFirstAdaptiveFormat(Arrays.asList(
-                    androidStreamingData, iosStreamingData));
+                    androidStreamingData, androidVRStreamingData, iosStreamingData));
         }
     }
 
@@ -626,7 +629,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         // There is no DASH manifest available with the iOS client
         return getManifestUrl(
                 "dash",
-                List.of(new Pair<>(androidStreamingData, androidStreamingUrlsPoToken)),
+                List.of(new Pair<>(androidStreamingData, androidStreamingUrlsPoToken),
+                        new Pair<>(androidVRStreamingData, (String) null)),
                 // Return version 7 of the DASH manifest, which is the latest one, reducing
                 // manifest size and allowing playback with some DASH players
                 "mpd_version=7");
@@ -645,7 +649,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         return getManifestUrl(
                 "hls",
                 List.of(new Pair<>(iosStreamingData, iosStreamingUrlsPoToken),
-                        new Pair<>(androidStreamingData, androidStreamingUrlsPoToken)),
+                        new Pair<>(androidStreamingData, androidStreamingUrlsPoToken),
+                        new Pair<>(androidVRStreamingData, (String) null)),
                 "");
     }
 
@@ -845,6 +850,10 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
         fetchAndroidClient(localization, contentCountry, videoId, androidPoTokenResult);
 
+        if (isSabrOnlyStreamingData(androidStreamingData)) {
+            fetchAndroidVRClient(localization, contentCountry, videoId);
+        }
+
         setStreamType();
 
         if (fetchIosClient) {
@@ -948,6 +957,38 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
         if (androidPoTokenResult != null) {
             androidStreamingUrlsPoToken = androidPoTokenResult.streamingDataPoToken;
+        }
+    }
+
+    private static boolean isSabrOnlyStreamingData(@Nullable final JsonObject streamingData) {
+        if (streamingData == null) {
+            return true;
+        }
+        final JsonArray adaptiveFormats = streamingData.getArray(ADAPTIVE_FORMATS);
+        if (adaptiveFormats == null || adaptiveFormats.isEmpty()) {
+            return true;
+        }
+        for (int i = 0; i < adaptiveFormats.size(); i++) {
+            final JsonObject fmt = adaptiveFormats.getObject(i);
+            if (fmt.has("url") || fmt.has(SIGNATURE_CIPHER) || fmt.has(CIPHER)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void fetchAndroidVRClient(@Nonnull final Localization localization,
+                                      @Nonnull final ContentCountry contentCountry,
+                                      @Nonnull final String videoId) {
+        try {
+            androidVRCpn = generateContentPlaybackNonce();
+            final JsonObject vrPlayerResponse =
+                    YoutubeStreamHelper.getAndroidVRPlayerResponse(
+                            contentCountry, localization, videoId, androidVRCpn);
+            if (!isPlayerResponseNotValid(vrPlayerResponse, videoId)) {
+                androidVRStreamingData = vrPlayerResponse.getObject(STREAMING_DATA);
+            }
+        } catch (final Exception ignored) {
         }
     }
 
@@ -1108,6 +1149,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             java.util.stream.Stream.of(
                     new Pair<>(androidStreamingData,
                             new Pair<>(androidCpn, androidStreamingUrlsPoToken)),
+                    new Pair<>(androidVRStreamingData,
+                            new Pair<>(androidVRCpn, (String) null)),
                     new Pair<>(iosStreamingData,
                             new Pair<>(iosCpn, iosStreamingUrlsPoToken)))
                     .flatMap(pair -> getStreamsFromStreamingDataKey(

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
@@ -410,14 +410,8 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
         throw new ParsingException("Failed to determine channel image view model");
     }
 
-    private Optional<JsonObject> metadataPart(final int rowIndex, final int partIndex)
-        throws ParsingException {
-        if (cachedMetadataRows == null) {
-            cachedMetadataRows = JsonUtils.getArray(lockupViewModel,
-                "metadata.lockupMetadataViewModel.metadata"
-                    + ".contentMetadataViewModel.metadataRows");
-        }
-        return cachedMetadataRows
+    private Optional<JsonObject> metadataPart(final int rowIndex, final int partIndex) {
+        return getMetadataRows()
             .streamAsJsonObjects()
             .skip(rowIndex)
             .limit(1)
@@ -441,19 +435,27 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
         return 1;
     }
 
+    private JsonArray getMetadataRows() {
+        if (cachedMetadataRows == null) {
+            try {
+                cachedMetadataRows = JsonUtils.getArray(lockupViewModel,
+                    "metadata.lockupMetadataViewModel.metadata"
+                        + ".contentMetadataViewModel.metadataRows");
+            } catch (final ParsingException e) {
+                // Some lockups don't have metadata rows at all
+                cachedMetadataRows = new JsonArray();
+            }
+        }
+        return cachedMetadataRows;
+    }
+
     /**
      * Searches the metadata parts of a specific row for text matching the given predicate.
      * This handles variable part order (e.g. [views, date] vs [date, views]) within a row.
      */
     private Optional<String> findMetadataPartInRow(final int rowIndex,
-                                                   @Nonnull final Predicate<String> predicate)
-            throws ParsingException {
-        if (cachedMetadataRows == null) {
-            cachedMetadataRows = JsonUtils.getArray(lockupViewModel,
-                "metadata.lockupMetadataViewModel.metadata"
-                    + ".contentMetadataViewModel.metadataRows");
-        }
-        return cachedMetadataRows
+                                                   @Nonnull final Predicate<String> predicate) {
+        return getMetadataRows()
             .streamAsJsonObjects()
             .skip(rowIndex)
             .limit(1)
@@ -469,14 +471,8 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
      * Used as a fallback when the info row doesn't contain the expected data,
      * e.g. for livestreams with only 1 metadata row in search results.
      */
-    private Optional<String> findMetadataPartInAllRows(@Nonnull final Predicate<String> predicate)
-            throws ParsingException {
-        if (cachedMetadataRows == null) {
-            cachedMetadataRows = JsonUtils.getArray(lockupViewModel,
-                "metadata.lockupMetadataViewModel.metadata"
-                    + ".contentMetadataViewModel.metadataRows");
-        }
-        return cachedMetadataRows
+    private Optional<String> findMetadataPartInAllRows(@Nonnull final Predicate<String> predicate) {
+        return getMetadataRows()
             .streamAsJsonObjects()
             .flatMap(jsonObject -> jsonObject.getArray("metadataParts")
                 .streamAsJsonObjects())

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemLockupExtractor.java
@@ -12,6 +12,7 @@ import org.schabi.newpipe.extractor.localization.TimeAgoParser;
 import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeChannelLinkHandlerFactory;
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeStreamLinkHandlerFactory;
+import org.schabi.newpipe.extractor.stream.ContentAvailability;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemExtractor;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.utils.JsonUtils;
@@ -508,6 +509,36 @@ public class YoutubeStreamInfoItemLockupExtractor implements StreamInfoItemExtra
         return getDateText().map(dateText -> dateText.contains(PREMIERES_TEXT))
                 // If we can't get date text, assume it is not a premiere, it should be a livestream
                 .orElse(false);
+    }
+
+    private boolean isMembersOnly() throws ParsingException {
+        if (cachedMetadataRows == null) {
+            cachedMetadataRows = JsonUtils.getArray(lockupViewModel,
+                    "metadata.lockupMetadataViewModel.metadata"
+                            + ".contentMetadataViewModel.metadataRows");
+        }
+
+        return cachedMetadataRows
+                .streamAsJsonObjects()
+                .flatMap(jsonObject -> jsonObject.getArray("badges")
+                        .streamAsJsonObjects())
+                .map(badge -> badge.getObject("badgeViewModel").getString("badgeStyle"))
+                .anyMatch("BADGE_MEMBERS_ONLY"::equals);
+    }
+
+
+    @Nonnull
+    @Override
+    public ContentAvailability getContentAvailability() throws ParsingException {
+        if (isPremiere()) {
+            return ContentAvailability.UPCOMING;
+        }
+
+        if (isMembersOnly()) {
+            return ContentAvailability.MEMBERSHIP;
+        }
+
+        return ContentAvailability.AVAILABLE;
     }
 
     abstract static class ChannelImageViewModel {

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamInfoItemTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamInfoItemTest.java
@@ -279,6 +279,141 @@ class YoutubeStreamInfoItemTest {
         );
     }
 
+    /**
+     * Tests 2-row format in search/related/kiosk where row 1 exists but contains
+     * non-views text. Verifies that the default getInfoMetadataRowIndex()=1 context
+     * does not crash and returns -1 when row 1 has no matching view text.
+     */
+    @Test
+    void lockupViewModelTwoRowNonViewsRow1()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelTwoRowNonViewsRow1")
+                + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(
+                Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser);
+        // Uses default getInfoMetadataRowIndex() = 1 (search/related/kiosk context)
+        assertAll(
+        () -> assertEquals(StreamType.VIDEO_STREAM, extractor.getStreamType()),
+        () -> assertEquals("Two Row Non Views Row1", extractor.getName()),
+        () -> assertNull(extractor.getTextualUploadDate()),
+        () -> assertNull(extractor.getUploadDate()),
+        () -> assertEquals(-1, extractor.getViewCount()),
+        () -> assertEquals(-1, extractor.getDuration())
+        );
+    }
+
+    /**
+     * Tests channel tabs that unexpectedly have 2 rows [author][views,date].
+     * The override returns 0, but the views/date are actually in row 1.
+     * Verifies findMetadataPartInAllRows() fallback finds them correctly.
+     */
+    @Test
+    void lockupViewModelChannelTabTwoRows()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelChannelTabTwoRows")
+                + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(
+                Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser) {
+            // Channel tabs use 1-row format at index 0, but YouTube sometimes sends 2 rows
+            @Override
+            protected int getInfoMetadataRowIndex() {
+                return 0;
+            }
+        };
+        assertAll(
+        () -> assertEquals(StreamType.VIDEO_STREAM, extractor.getStreamType()),
+        () -> assertEquals("Channel Tab Two Rows", extractor.getName()),
+        () -> assertEquals("1 day ago", extractor.getTextualUploadDate()),
+        () -> assertNotNull(extractor.getUploadDate()),
+        () -> assertEquals(1200, extractor.getViewCount()),
+        () -> assertEquals(-1, extractor.getDuration())
+        );
+    }
+
+    /**
+     * Tests that scheduled premiere dates like "Scheduled for 27/05/2026, 18:01"
+     * don't match the date predicate and return null gracefully.
+     */
+    @Test
+    void lockupViewModelScheduledDate()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelScheduledDate")
+                + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(
+                Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser) {
+            @Override
+            protected int getInfoMetadataRowIndex() {
+                return 0;
+            }
+        };
+        assertAll(
+        () -> assertEquals(StreamType.VIDEO_STREAM, extractor.getStreamType()),
+        () -> assertEquals("Scheduled Date Video", extractor.getName()),
+        // "Scheduled for..." does not end with "ago" nor contain "Premieres "
+        () -> assertNull(extractor.getTextualUploadDate()),
+        () -> assertNull(extractor.getUploadDate()),
+        () -> assertEquals(-1, extractor.getViewCount()),
+        () -> assertEquals(-1, extractor.getDuration())
+        );
+    }
+
+    /**
+     * Tests that an empty metadataParts array doesn't crash.
+     */
+    @Test
+    void lockupViewModelEmptyMetadataParts()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelEmptyMetadataParts")
+                + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(
+                Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser) {
+            @Override
+            protected int getInfoMetadataRowIndex() {
+                return 0;
+            }
+        };
+        assertAll(
+        () -> assertEquals(StreamType.VIDEO_STREAM, extractor.getStreamType()),
+        () -> assertEquals("Empty Metadata Parts", extractor.getName()),
+        () -> assertNull(extractor.getTextualUploadDate()),
+        () -> assertNull(extractor.getUploadDate()),
+        () -> assertEquals(-1, extractor.getViewCount()),
+        () -> assertEquals(-1, extractor.getDuration())
+        );
+    }
+
+    /**
+     * Tests that findMetadataPartInAllRows() correctly finds views in row 0
+     * when the default info row (row 1) does not contain them.
+     */
+    @Test
+    void lockupViewModelViewsInRow0()
+            throws FileNotFoundException, JsonParserException {
+        final var json = JsonParser.object().from(new FileInputStream(getMockPath(
+                YoutubeStreamInfoItemTest.class, "lockupViewModelViewsInRow0")
+                + ".json"));
+        final var timeAgoParser = TimeAgoPatternsManager.getTimeAgoParserFor(
+                Localization.DEFAULT);
+        final var extractor = new YoutubeStreamInfoItemLockupExtractor(json, timeAgoParser);
+        // Uses default getInfoMetadataRowIndex() = 1, but views are in row 0
+        assertAll(
+        () -> assertEquals(StreamType.LIVE_STREAM, extractor.getStreamType()),
+        () -> assertEquals("Views In Row0", extractor.getName()),
+        () -> assertNull(extractor.getTextualUploadDate()),
+        () -> assertNull(extractor.getUploadDate()),
+        () -> assertEquals(500, extractor.getViewCount()),
+        () -> assertEquals(-1, extractor.getDuration())
+        );
+    }
+
     @Test
     void emptyTitle() throws FileNotFoundException, JsonParserException {
         final var json = JsonParser.object().from(new FileInputStream(getMockPath(

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelchanneltabtworows.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelchanneltabtworows.json
@@ -1,0 +1,62 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/CHANNEL_TAB_TWO_ROWS_ID/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          }
+        ]
+      },
+      "overlays": []
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "Channel Tab Two Rows"
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "The Author",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            },
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "1.2K views",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                },
+                {
+                  "text": {
+                    "content": "1 day ago",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            }
+          ],
+          "delimiter": " • "
+        }
+      },
+      "menuButton": {}
+    }
+  },
+  "contentId": "CHANNEL_TAB_TWO_ROWS_ID",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelemptymetadataparts.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelemptymetadataparts.json
@@ -1,0 +1,36 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/EMPTY_METADATA_PARTS_ID/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          }
+        ]
+      },
+      "overlays": []
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "Empty Metadata Parts"
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": []
+            }
+          ],
+          "delimiter": " • "
+        }
+      },
+      "menuButton": {}
+    }
+  },
+  "contentId": "EMPTY_METADATA_PARTS_ID",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelscheduleddate.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelscheduleddate.json
@@ -1,0 +1,57 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/SCHEDULED_DATE_ID/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          }
+        ]
+      },
+      "overlays": [
+        {
+          "thumbnailBottomOverlayViewModel": {
+            "badges": [
+              {
+                "thumbnailBadgeViewModel": {
+                  "badgeStyle": "THUMBNAIL_OVERLAY_BADGE_STYLE_PREMIERE",
+                  "text": "PREMIERE"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "Scheduled Date Video"
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "Scheduled for 27/05/2026, 18:01",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            }
+          ],
+          "delimiter": " • "
+        }
+      },
+      "menuButton": {}
+    }
+  },
+  "contentId": "SCHEDULED_DATE_ID",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodeltworownonviewsrow1.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodeltworownonviewsrow1.json
@@ -1,0 +1,55 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/TWO_ROW_NON_VIEWS_ROW1_ID/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          }
+        ]
+      },
+      "overlays": []
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "Two Row Non Views Row1"
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "The Author",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            },
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "Some random text",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            }
+          ],
+          "delimiter": " • "
+        }
+      },
+      "menuButton": {}
+    }
+  },
+  "contentId": "TWO_ROW_NON_VIEWS_ROW1_ID",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}

--- a/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelviewsinrow0.json
+++ b/extractor/src/test/resources/mocks/v1/org/schabi/newpipe/extractor/services/youtube/youtubestreaminfoitem/lockupviewmodelviewsinrow0.json
@@ -1,0 +1,68 @@
+{
+  "contentImage": {
+    "thumbnailViewModel": {
+      "image": {
+        "sources": [
+          {
+            "url": "https://i.ytimg.com/vi/VIEWS_IN_ROW0_ID/hqdefault.jpg",
+            "width": 168,
+            "height": 94
+          }
+        ]
+      },
+      "overlays": [
+        {
+          "thumbnailBottomOverlayViewModel": {
+            "badges": [
+              {
+                "thumbnailBadgeViewModel": {
+                  "badgeStyle": "THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE",
+                  "text": "LIVE"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "lockupMetadataViewModel": {
+      "title": {
+        "content": "Views In Row0"
+      },
+      "metadata": {
+        "contentMetadataViewModel": {
+          "metadataRows": [
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "500 watching",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            },
+            {
+              "metadataParts": [
+                {
+                  "text": {
+                    "content": "The Author",
+                    "styleRuns": [],
+                    "attachmentRuns": []
+                  }
+                }
+              ]
+            }
+          ],
+          "delimiter": " • "
+        }
+      },
+      "menuButton": {}
+    }
+  },
+  "contentId": "VIEWS_IN_ROW0_ID",
+  "contentType": "LOCKUP_CONTENT_TYPE_VIDEO"
+}


### PR DESCRIPTION
1) [YouTube] Support content availability check for lockup videos tab
Implements support for retrieving the content availability of streams extracted
from the videos tab using lockup metadata.

2) Add ANDROID_VR client as fallback for SABR-only responses,
YouTube is enforcing the SABR protocol on standard clients (WEB, ANDROID),
which removes traditional stream URLs from adaptive formats. This leaves
only the progressive 360p stream (itag 18) playable.
This adds the ANDROID_VR client (Oculus Quest 3, client ID 28) as a
fallback when the regular Android client returns SABR-only streaming
data (adaptive formats without url/signatureCipher fields). The VR
client still receives traditional stream URLs from YouTube.

Changes:
- Add ANDROID_VR client constants and InnertubeClientRequestInfo factory
- Add getAndroidVRPlayerResponse in YoutubeStreamHelper
- Detect SABR-only responses via isSabrOnlyStreamingData helper
- Fall back to VR client in onFetchPage when SABR detected
- Include VR streaming data in getItags, DASH/HLS manifest, and duration

3) [YouTube] Support content availability check for lockup videos tab, Implements support for retrieving the content availability of streams extracted
from the videos tab using lockup metadata.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
