### PR TITLE
fix YouTube Music search: add fallback videoId extraction paths

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMusicSongOrVideoInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMusicSongOrVideoInfoItemExtractor.java
@@ -37,10 +37,37 @@ public class YoutubeMusicSongOrVideoInfoItemExtractor implements StreamInfoItemE
 
     @Override
     public String getUrl() throws ParsingException {
+        // Primary: playlistItemData.videoId (legacy, may be absent)
         final String id = songOrVideoInfoItem.getObject("playlistItemData").getString("videoId");
         if (!isNullOrEmpty(id)) {
             return "https://music.youtube.com/watch?v=" + id;
         }
+
+        // Fallback: overlay play button watchEndpoint
+        final String overlayId = songOrVideoInfoItem.getObject("overlay")
+                .getObject("musicItemThumbnailOverlayRenderer")
+                .getObject("content")
+                .getObject("musicPlayButtonRenderer")
+                .getObject("playNavigationEndpoint")
+                .getObject("watchEndpoint")
+                .getString("videoId");
+        if (!isNullOrEmpty(overlayId)) {
+            return "https://music.youtube.com/watch?v=" + overlayId;
+        }
+
+        // Fallback: song title navigationEndpoint
+        final String flexUrl = getUrlFromNavigationEndpoint(
+                songOrVideoInfoItem.getArray("flexColumns")
+                        .getObject(0)
+                        .getObject("musicResponsiveListItemFlexColumnRenderer")
+                        .getObject("text")
+                        .getArray("runs")
+                        .getObject(0)
+                        .getObject("navigationEndpoint"));
+        if (!isNullOrEmpty(flexUrl)) {
+            return flexUrl;
+        }
+
         throw new ParsingException("Could not get URL");
     }
 


### PR DESCRIPTION
YouTube removed the videoId from playlistItemData in music search results, breaking all music_songs searches with "Could not get URL".

Added two fallback paths verified against current YouTube Music response format:
- overlay.musicItemThumbnailOverlayRenderer play button watchEndpoint
- flexColumns[0] song title navigationEndpoint

The original playlistItemData path is retained for backward compatibility.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
